### PR TITLE
Removing extra line in docblocks

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -976,10 +976,19 @@ function printNode(path, options, print) {
       return node.isDoc
         ? concat([
             "/**",
-            concat(
-              node.lines.map(comment => concat([hardline, " * ", comment]))
-            ),
-            hardline,
+            // we use the number of lines to determine if this is a single or
+            // multi line docblock
+            node.lines.length > 1
+              ? concat(
+                  node.lines.map(
+                    (comment, index) =>
+                      index != 0 && index != node.lines.length - 1
+                        ? concat([hardline, " * ", comment])
+                        : ""
+                  )
+                )
+              : concat([" ", node.lines[0]], " "),
+            node.lines.length > 1 ? hardline : "",
             " */"
           ])
         : concat(node.lines.map(comment => concat(["// ", comment])));

--- a/tests/class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class/__snapshots__/jsfmt.spec.js.snap
@@ -54,9 +54,7 @@ abstract class ReallyReallyReallyLongClassName
   public $other = 1;
   public static  $staticTest = ['hi'];
   /**
-   *
    * This is a function
-   *
    */
   private function hi($input) {
     return $input . $this->test;

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`comments.php 1`] = `
+<?php
+/** @var int $int This is a counter. */
+$int = 0;
+
+// there should be no docblock here
+$int++;
+
+/**
+ * This class acts as an example on where to position a DocBlock.
+ */
+class Foo
+{
+    /** @var string|null $title contains a title for the Foo with a max. length of 24 characters */
+    protected $title = null;
+
+    /**
+     * Sets a single-line title.
+     *
+     * @param string $title A text with a maximum of 24 characters.
+     *
+     * @return void
+     */
+    public function setTitle($title)
+    {
+        // there should be no docblock here
+        $this->title = $title;
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?php
+/** @var int $int This is a counter. */
+$int = 0;
+// there should be no docblock here
+$int++;
+/**
+ * This class acts as an example on where to position a DocBlock.
+ */
+class Foo {
+
+  /** @var string|null $title contains a title for the Foo with a max. length of 24 characters */
+  protected $title = null;
+  /**
+   * Sets a single-line title.
+   *
+   * @param string $title A text with a maximum of 24 characters.
+   *
+   * @return void
+   */
+  public function setTitle($title) {
+    // there should be no docblock here
+    $this->title = $title;
+  }
+}
+`;

--- a/tests/comments/comments.php
+++ b/tests/comments/comments.php
@@ -1,0 +1,28 @@
+<?php
+/** @var int $int This is a counter. */
+$int = 0;
+
+// there should be no docblock here
+$int++;
+
+/**
+ * This class acts as an example on where to position a DocBlock.
+ */
+class Foo
+{
+    /** @var string|null $title contains a title for the Foo with a max. length of 24 characters */
+    protected $title = null;
+
+    /**
+     * Sets a single-line title.
+     *
+     * @param string $title A text with a maximum of 24 characters.
+     *
+     * @return void
+     */
+    public function setTitle($title)
+    {
+        // there should be no docblock here
+        $this->title = $title;
+    }
+}

--- a/tests/comments/jsfmt.spec.js
+++ b/tests/comments/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["php"]);


### PR DESCRIPTION
Added test case for comments and fixed printer to not add extra lines at beginning/end of docblocks