### PR TITLE
Optimize wrapping of long calls

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -737,12 +737,22 @@ function printStatement(path, options, print) {
         "}"
       ]);
     case "call":
-      return concat([
-        path.call(print, "what"),
-        "(",
-        join(", ", path.map(print, "arguments")),
-        ")"
-      ]);
+      return group(
+        concat([
+          path.call(print, "what"),
+          concat([
+            "(",
+            indent(
+              concat([
+                softline,
+                join(concat([",", line]), path.map(print, "arguments"))
+              ])
+            ),
+            softline,
+            ")"
+          ])
+        ])
+      );
     case "usegroup":
       return concat([
         "use ",

--- a/tests/class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class/__snapshots__/jsfmt.spec.js.snap
@@ -35,6 +35,8 @@ abstract class ReallyReallyReallyLongClassName extends AbstractModelFactoryResou
     return self::$staticTest[0];
   }
 }
+
+$this->something->method($argument, $this->more->stuff($this->even->more->things->complicatedMethod()));
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 class Foo extends Bar implements Baz, Buzz {
@@ -76,4 +78,9 @@ abstract class ReallyReallyReallyLongClassName
     return self::$staticTest[0];
   }
 }
+
+$this->something->method(
+  $argument,
+  $this->more->stuff($this->even->more->things->complicatedMethod())
+);
 `;

--- a/tests/class/class.php
+++ b/tests/class/class.php
@@ -32,3 +32,5 @@ abstract class ReallyReallyReallyLongClassName extends AbstractModelFactoryResou
     return self::$staticTest[0];
   }
 }
+
+$this->something->method($argument, $this->more->stuff($this->even->more->things->complicatedMethod()));

--- a/tests/functions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/functions/__snapshots__/jsfmt.spec.js.snap
@@ -78,9 +78,12 @@ $anonymousLongVariableName = function (
 };
 
 $arr = [1, 2, 3];
-array_map(function ($entry) {
-  return $entry * 2;
-}, $arr);
+array_map(
+  function ($entry) {
+    return $entry * 2;
+  },
+  $arr
+);
 
 $silent = @hello();
 `;


### PR DESCRIPTION
I wanted to optimize the handling of long calls like this one:
```php
$this->something->method($argument, $this->more->stuff($this->even->more->things->complicatedMethod()));
```
which used to be turned into
```php
$this->something->method($argument, $this->more->stuff($this->even->more->
  things->
  complicatedMethod()));
```
and would now be turned into
```php
$this->something->method(
  $argument,
  $this->more->stuff($this->even->more->things->complicatedMethod())
);
```
This seems to be PSR-2 compliant as far as i can tell ([see here](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#46-method-and-function-calls)).

However, it's this would also change the way functions like `array_map` would be printed like:
```php
array_map(
  function ($entry) {
    return $entry * 2;
  },
  $arr
);
```
instead of
```php
array_map(function ($entry) {
    return $entry * 2;
  }, $arr);
```
which looks a bit strange. Let me know what you think 😄 