### PR TITLE
Use multi-line print for all multi-line node types

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -843,23 +843,16 @@ function printStatement(path, options, print) {
         const directive = Object.keys(path.getValue().what)[0];
         return concat([directive, "=", path.call(print, "what", directive)]);
       };
-      const printDeclareChildren = function(path) {
-        return concat(
-          path.map(child => {
-            return concat([
-              print(child),
-              lineShouldEndWithSemicolon(child) ? ";" : ""
-            ]);
-          }, "children")
-        );
-      };
       if (node.mode === "short") {
         return concat([
           "declare(",
           printDeclareArguments(path),
           "):",
           hardline,
-          printDeclareChildren(path),
+          path.call(
+            childrenPath => printLines(childrenPath, options, print),
+            "children"
+          ),
           hardline,
           "enddeclare;"
         ]);
@@ -868,7 +861,15 @@ function printStatement(path, options, print) {
           "declare(",
           printDeclareArguments(path),
           ") {",
-          indent(concat([hardline, printDeclareChildren(path)])),
+          indent(
+            concat([
+              hardline,
+              path.call(
+                childrenPath => printLines(childrenPath, options, print),
+                "children"
+              )
+            ])
+          ),
           hardline,
           "}"
         ]);
@@ -878,7 +879,10 @@ function printStatement(path, options, print) {
         printDeclareArguments(path),
         ");",
         hardline,
-        printDeclareChildren(path)
+        path.call(
+          childrenPath => printLines(childrenPath, options, print),
+          "children"
+        )
       ]);
     }
     case "global":

--- a/src/printer.js
+++ b/src/printer.js
@@ -62,6 +62,36 @@ function lineShouldEndWithSemicolon(path) {
   return includes(semiColonWhitelist, node.kind);
 }
 
+function isLastStatement(path) {
+  const parent = path.getParentNode();
+  if (!parent) {
+    return true;
+  }
+  const node = path.getValue();
+  const body = parent.children;
+  return body && body[body.length - 1] === node;
+}
+
+function printLines(path, options, print) {
+  const text = options.originalText;
+  const printed = path.map(stmtPath => {
+    const stmt = stmtPath.getValue();
+    const parts = [];
+    parts.push(print(stmtPath));
+    if (lineShouldEndWithSemicolon(stmtPath)) {
+      parts.push(";");
+    }
+    if (
+      util.isNextLineEmpty(text, stmt, options) &&
+      !isLastStatement(stmtPath)
+    ) {
+      parts.push(hardline);
+    }
+    return concat(parts);
+  });
+  return join(hardline, printed);
+}
+
 const expressionKinds = [
   "array",
   "variable",
@@ -324,29 +354,16 @@ function printStatement(path, options, print) {
   function printBlock(path, options, print) {
     switch (node.kind) {
       case "block":
-        return concat(
-          path.map((child, i) => {
-            if (i === 0) {
-              return concat([
-                print(child),
-                lineShouldEndWithSemicolon(child) ? ";" : ""
-              ]);
-            }
-            return concat([
-              hardline,
-              concat([
-                print(child),
-                lineShouldEndWithSemicolon(child) ? ";" : ""
-              ])
-            ]);
-          }, "children")
+        return path.call(
+          childrenPath => printLines(childrenPath, options, print),
+          "children"
         );
       case "program": {
         return concat([
           "<?php",
           hardline,
           path.call(childrenPath => {
-            return printStatementSequence(childrenPath, options, print);
+            return printLines(childrenPath, options, print);
           }, "children")
         ]);
       }
@@ -447,7 +464,7 @@ function printStatement(path, options, print) {
             concat([
               hardline,
               path.call(bodyPath => {
-                return printStatementSequence(bodyPath, options, print);
+                return printLines(bodyPath, options, print);
               }, "body")
             ])
           ),
@@ -1072,37 +1089,6 @@ function printNode(path, options, print) {
     default:
       return "Have not implemented kind " + node.kind + " yet.";
   }
-}
-
-function isLastStatement(path) {
-  const parent = path.getParentNode();
-  if (!parent) {
-    return true;
-  }
-  const node = path.getValue();
-  const body = parent.children;
-  return body && body[body.length - 1] === node;
-}
-
-function printStatementSequence(path, options, print) {
-  const printed = [];
-  const text = options.originalText;
-  path.map(stmtPath => {
-    const stmt = stmtPath.getValue();
-    const parts = [];
-    parts.push(print(stmtPath));
-    if (lineShouldEndWithSemicolon(stmtPath)) {
-      parts.push(";");
-    }
-    if (
-      util.isNextLineEmpty(text, stmt, options) &&
-      !isLastStatement(stmtPath)
-    ) {
-      parts.push(hardline);
-    }
-    printed.push(concat(parts));
-  });
-  return join(hardline, printed);
 }
 
 module.exports = genericPrint;

--- a/src/printer.js
+++ b/src/printer.js
@@ -1054,15 +1054,14 @@ function printNode(path, options, print) {
             ? concat([
                 " {",
                 indent(
-                  concat(
-                    path.map(adaptationPath => {
-                      return concat([
-                        line,
-                        print(adaptationPath),
-                        lineShouldEndWithSemicolon(adaptationPath) ? ";" : ""
-                      ]);
-                    }, "adaptations")
-                  )
+                  concat([
+                    line,
+                    path.call(
+                      adaptationsPath =>
+                        printLines(adaptationsPath, options, print),
+                      "adaptations"
+                    )
+                  ])
                 ),
                 line,
                 "}"

--- a/tests/class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class/__snapshots__/jsfmt.spec.js.snap
@@ -45,7 +45,15 @@ abstract class ReallyReallyReallyLongClassName extends AbstractModelFactoryResou
    * This is a function
    */
   private function hi($input) {
+    $test = 1;
+
+    //testing line spacing
+    $other_test = 2;
+
+
+    $one_more_test = 3;
     return $input . $this->test;
+
   }
 
   public function reallyReallyReallyReallyReallyReallyReallyLongMethodName($input, $otherInput = 1) {
@@ -117,6 +125,12 @@ abstract class ReallyReallyReallyLongClassName
    */
   private function hi($input)
   {
+    $test = 1;
+
+    // testing line spacing
+    $other_test = 2;
+
+    $one_more_test = 3;
     return $input . $this->test;
   }
 

--- a/tests/class/class.php
+++ b/tests/class/class.php
@@ -42,7 +42,15 @@ abstract class ReallyReallyReallyLongClassName extends AbstractModelFactoryResou
    * This is a function
    */
   private function hi($input) {
+    $test = 1;
+
+    //testing line spacing
+    $other_test = 2;
+
+
+    $one_more_test = 3;
     return $input . $this->test;
+
   }
 
   public function reallyReallyReallyReallyReallyReallyReallyLongMethodName($input, $otherInput = 1) {


### PR DESCRIPTION
Reusing solution from #14 for other functions that need to print multiple lines