### PR TITLE
Fixing multi-line comments

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1048,7 +1048,7 @@ function printNode(path, options, print) {
             node.lines.length > 1 ? hardline : "",
             " */"
           ])
-        : concat(node.lines.map(comment => concat(["// ", comment])));
+        : join(hardline, node.lines.map(comment => concat(["// ", comment])));
     case "entry":
       return concat([
         node.key ? concat([path.call(print, "key"), " => "]) : "",

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -8,6 +8,12 @@ $int = 0;
 // there should be no docblock here
 $int++;
 
+// multi
+// line
+// comment
+// test
+$hi = 1;
+
 /**
  * This class acts as an example on where to position a DocBlock.
  */
@@ -36,6 +42,12 @@ $int = 0;
 
 // there should be no docblock here
 $int++;
+
+// multi
+// line
+// comment
+// test
+$hi = 1;
 
 /**
  * This class acts as an example on where to position a DocBlock.

--- a/tests/comments/comments.php
+++ b/tests/comments/comments.php
@@ -5,6 +5,12 @@ $int = 0;
 // there should be no docblock here
 $int++;
 
+// multi
+// line
+// comment
+// test
+$hi = 1;
+
 /**
  * This class acts as an example on where to position a DocBlock.
  */


### PR DESCRIPTION
For multi-line comments (not docblocks) we weren't printing new lines